### PR TITLE
Make get_post_types arguments filterable

### DIFF
--- a/acf-posttype-select-v4.php
+++ b/acf-posttype-select-v4.php
@@ -179,7 +179,7 @@ class acf_field_posttype_select extends acf_field
      */
     private function post_type_options()
     {
-        $args = array( 'public' => true );
+        $args = apply_filters('acf_field_posttype_select/get_post_types_args', array( 'public' => true ));
         $post_types = get_post_types($args, 'objects');
         $output = array();
         foreach ($post_types as $post_type) {

--- a/acf-posttype-select-v5.php
+++ b/acf-posttype-select-v5.php
@@ -210,7 +210,7 @@ class acf_field_posttype_select extends acf_field
      */
     private function post_type_options()
     {
-        $args = array( 'public' => true );
+        $args = apply_filters('acf_field_posttype_select/get_post_types_args', array( 'public' => true ));
         $post_types = get_post_types($args, 'objects');
         $output = array();
         foreach ($post_types as $post_type) {


### PR DESCRIPTION
For most use-cases, setting the 'public' parameter to true for `get_post_types` will work. However, we should grant users the ability to hook into this option to modify as needed, in case a post type is not public (has no URL) but is publicly queryable (used in front-end queries).

This will give users the ability to do something like this:

```php
add_filter('acf_field_posttype_select/get_post_types_args', function($args){
    return ['publicly_queryable' => true];
});
```